### PR TITLE
Use tasmota release solo1 core1.0.6

### DIFF
--- a/Devices/Ceiling Yeelight YLXD41YL/ceiling_yeelight_ylxd41xl.yaml
+++ b/Devices/Ceiling Yeelight YLXD41YL/ceiling_yeelight_ylxd41xl.yaml
@@ -9,8 +9,7 @@ esphome:
   board: esp32doit-devkit-v1
   platformio_options:
     platform: espressif32@3.0.0
-    platform_packages: |-4
-          framework-arduinoespressif32 @ https://github.com/Jason2866/esp32-arduino-lib-builder/raw/framework-arduinoespressif32/framework-arduinoespressif32-release_v3.3-solo1-bd65eb8d1.tar.gz
+    platform_packages: tasmota/framework-arduinoespressif32 @ 3.10006.210420
 
 #wifi:
 #  use_address: 10.25.30.105


### PR DESCRIPTION
The custom build isn't available anymore: https://github.com/Jason2866/esp32-arduino-lib-builder/raw/framework-arduinoespressif32/framework-arduinoespressif32-release_v3.3-solo1-bd65eb8d1.tar.gz -> returns 404

https://github.com/arendst/Tasmota/commit/9bd46df6007c3272049458406acd111da30a9e59#diff-ebebbfa1b5737117b01c43f27a1f78f7d2c75bf3bfa353b6a0d1818357b23205